### PR TITLE
ara::core::Byte implementation 

### DIFF
--- a/include/ara/core/byte.h
+++ b/include/ara/core/byte.h
@@ -12,8 +12,9 @@
 
 namespace ara::core {
 /**
- * @brief Wrapper class for std::byte class
+ * @brief Wrapper class for std::byte class object
  *
+ * @req {SWS_CORE_10100}
  */
 class ByteImpl
 {
@@ -23,25 +24,30 @@ class ByteImpl
     /**
      * @brief Construct a new Byte Impl object with no defined value
      *
+     * @req {SWS_CORE_10104}
      */
     ByteImpl() = default;
     /**
      * @brief Constuct object with given value
      * @arg Value of byte
      *
+     * @req {SWS_CORE_10102, SWS_CORE_10103}
      */
     constexpr explicit ByteImpl(ByteType value) : impl{value} {}
 
     /**
      * @brief Default destructor
      *
+     * @req {SWS_CORE_10105}
      */
     ~ByteImpl() = default;
 
     /**
-     * @brief Cast operator for machine byte type
+     * @brief Cast operator for machine byte type. Allowed only explicit
+     * conversion
      *
      * @return ByteType Value of byte given in byte machine type
+     * @req {SWS_CORE_10106, SWS_CORE_10107, SWS_CORE_10108}
      */
     constexpr explicit operator ByteType() const
     {
@@ -49,22 +55,20 @@ class ByteImpl
     }
 
     /**
-     * @brief Equality operator for Byte object
+     * @brief Primart equality operator for Byte object
      *
      * @return true When given Byte object is equal
      * @return false When given Byte object is not equal
+     * @req {SWS_CORE_10109, SWS_CORE_10110}
      */
     constexpr bool operator==(const ByteImpl&) const = default;
 
-    /**
-     * @brief No equality operator for Byte object
-     *
-     * @return true When given Byte object is not equal
-     * @return false When given Byte object is equal
-     */
-    constexpr bool operator!=(const ByteImpl&) const = default;
-
  private:
+    /**
+     * @brief Only member is std::byte object which contains value
+     *
+     * @req {SWS_CORE_10101}
+     */
     std::byte impl;
 };
 
@@ -84,9 +88,9 @@ to_integer(ByteImpl b) noexcept requires std::integral<IntegerType>
 /**
  * @brief Left shift operator for Byte object
  *
- * @tparam IntegerType Type of integer used by argument
+ * @tparam IntegerType Type of argument
  * @param b Byte object
- * @param shift Amount bits to shift
+ * @param shift Amount of bits to shift
  * @return constexpr ByteImpl Object with shifted value
  */
 template<class IntegerType> constexpr ByteImpl
@@ -99,9 +103,9 @@ operator<<(ByteImpl b, IntegerType shift) noexcept
 /**
  * @brief Left shift operator with assigment for Byte object
  *
- * @tparam IntegerType Type of integer used by argument
+ * @tparam IntegerType Type of argument
  * @param b Byte object
- * @param shift Amount bits to shift
+ * @param shift Amount of bits to shift
  * @return constexpr ByteImpl& Reference to object with shifted value
  */
 template<class IntegerType> constexpr ByteImpl&
@@ -114,9 +118,9 @@ operator<<=(ByteImpl& b, IntegerType shift) noexcept
 /**
  * @brief Right shift operator for Byte object
  *
- * @tparam IntegerType Type of integer used by argument
+ * @tparam IntegerType Type of argument
  * @param b Byte object
- * @param shift Amount bits to shift
+ * @param shift Amount of bits to shift
  * @return constexpr ByteImpl Object with shifted value
  */
 template<class IntegerType> constexpr ByteImpl
@@ -129,9 +133,9 @@ operator>>(ByteImpl b, IntegerType shift) noexcept
 /**
  * @brief Right shift operator with assigment for Byte object
  *
- * @tparam IntegerType Type of integer used by argument
+ * @tparam IntegerType Type of argument
  * @param b Byte object
- * @param shift Amount bits to shift
+ * @param shift Amount of bits to shift
  * @return constexpr ByteImpl& Reference to object with shifted value
  */
 template<class IntegerType> constexpr ByteImpl&
@@ -144,8 +148,8 @@ operator>>=(ByteImpl& b, IntegerType shift) noexcept
 /**
  * @brief Bitwise OR operator for Byte object
  *
- * @param l Left byte object
- * @param r Right byte object
+ * @param l First byte object
+ * @param r Second byte object
  * @return constexpr ByteImpl Object with result of OR operation
  */
 constexpr ByteImpl operator|(ByteImpl l, ByteImpl r) noexcept
@@ -157,8 +161,8 @@ constexpr ByteImpl operator|(ByteImpl l, ByteImpl r) noexcept
 /**
  * @brief Bitwise OR operator with assigment for Byte object
  *
- * @param l Left byte object
- * @param r Right byte object
+ * @param l First byte object
+ * @param r Second byte object
  * @return constexpr ByteImpl& Reference to object with result of OR operation
  */
 constexpr ByteImpl& operator|=(ByteImpl& l, ByteImpl r) noexcept
@@ -169,8 +173,8 @@ constexpr ByteImpl& operator|=(ByteImpl& l, ByteImpl r) noexcept
 /**
  * @brief Bitwise AND operator for Byte object
  *
- * @param l Left byte object
- * @param r Right byte object
+ * @param l First byte object
+ * @param r Second byte object
  * @return constexpr ByteImpl Object with result of AND operation
  */
 constexpr ByteImpl operator&(ByteImpl l, ByteImpl r) noexcept
@@ -182,8 +186,8 @@ constexpr ByteImpl operator&(ByteImpl l, ByteImpl r) noexcept
 /**
  * @brief Bitwise AND operator with assigment for Byte object
  *
- * @param l Left byte object
- * @param r Right byte object
+ * @param l First byte object
+ * @param r Second byte object
  * @return constexpr ByteImpl& Reference to object with result of AND operation
  */
 constexpr ByteImpl& operator&=(ByteImpl& l, ByteImpl r) noexcept
@@ -194,8 +198,8 @@ constexpr ByteImpl& operator&=(ByteImpl& l, ByteImpl r) noexcept
 /**
  * @brief Bitwise XOR operator for Byte object
  *
- * @param l Left byte object
- * @param r Right byte object
+ * @param l First byte object
+ * @param r Second byte object
  * @return constexpr ByteImpl Object with result of XOR operation
  */
 constexpr ByteImpl operator^(ByteImpl l, ByteImpl r) noexcept
@@ -207,8 +211,8 @@ constexpr ByteImpl operator^(ByteImpl l, ByteImpl r) noexcept
 /**
  * @brief Bitwise XOR operator with assigment for Byte object
  *
- * @param l Left byte object
- * @param r Right byte object
+ * @param l First byte object
+ * @param r Second byte object
  * @return constexpr ByteImpl& Reference to object with result of XOR operation
  */
 constexpr ByteImpl& operator^=(ByteImpl& l, ByteImpl r) noexcept
@@ -217,7 +221,7 @@ constexpr ByteImpl& operator^=(ByteImpl& l, ByteImpl r) noexcept
 }
 
 /**
- * @brief Bit inversion oprator for Byte object
+ * @brief Bit inversion operator for Byte object
  *
  * @param b Byte object
  * @return constexpr ByteImpl Object with value after inverting bits

--- a/include/ara/core/byte.h
+++ b/include/ara/core/byte.h
@@ -12,7 +12,7 @@
 
 namespace ara::core {
 /**
- * @brief Wrapper class for std::byte class object
+ * @brief Wrapper class for std::byte class object.
  *
  * @req {SWS_CORE_10100}
  */
@@ -22,13 +22,13 @@ class ByteImpl
     using ByteType = uint8_t;
 
     /**
-     * @brief Construct a new Byte Impl object with no defined value
+     * @brief Construct a new Byte Impl object with no defined value.
      *
      * @req {SWS_CORE_10104}
      */
     ByteImpl() = default;
     /**
-     * @brief Constuct object with given value
+     * @brief Constuct object with given value.
      * @arg Value of byte
      *
      * @req {SWS_CORE_10102, SWS_CORE_10103}
@@ -36,7 +36,7 @@ class ByteImpl
     constexpr explicit ByteImpl(ByteType value) : impl{value} {}
 
     /**
-     * @brief Default destructor
+     * @brief Default destructor.
      *
      * @req {SWS_CORE_10105}
      */
@@ -44,7 +44,7 @@ class ByteImpl
 
     /**
      * @brief Cast operator for machine byte type. Allowed only explicit
-     * conversion
+     * conversion.
      *
      * @return ByteType Value of byte given in byte machine type
      * @req {SWS_CORE_10106, SWS_CORE_10107, SWS_CORE_10108}
@@ -55,17 +55,32 @@ class ByteImpl
     }
 
     /**
-     * @brief Primart equality operator for Byte object
+     * @brief Equality operator for Byte object.
      *
      * @return true When given Byte object is equal
      * @return false When given Byte object is not equal
-     * @req {SWS_CORE_10109, SWS_CORE_10110}
+     * @req {SWS_CORE_10109}
      */
-    constexpr bool operator==(const ByteImpl&) const = default;
+    constexpr bool operator==(const ByteImpl& secondByteObject) const
+    {
+        return impl == secondByteObject.impl;
+    }
+
+    /**
+     * @brief Not-equality operator for Byte object.
+     *
+     * @return true When given Byte object is not equal
+     * @return false When given Byte object equal
+     * @req {SWS_CORE_10110}
+     */
+    constexpr bool operator!=(const ByteImpl& secondByteObject) const
+    {
+        return ! (*this == secondByteObject);
+    }
 
  private:
     /**
-     * @brief Only member is std::byte object which contains value
+     * @brief Only member is std::byte object which contains value.
      *
      * @req {SWS_CORE_10101}
      */
@@ -79,74 +94,75 @@ class ByteImpl
  * @param b Byte object
  * @return constexpr IntegerType Integer value
  */
-template<class IntegerType> constexpr IntegerType
-to_integer(ByteImpl b) noexcept requires std::integral<IntegerType>
+template<class IntegerType,
+         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+constexpr IntegerType to_integer(ByteImpl b) noexcept
 {
     return IntegerType(static_cast<ByteImpl::ByteType>(b));
 }
 
 /**
- * @brief Left shift operator for Byte object
+ * @brief Left shift operator for Byte object.
  *
  * @tparam IntegerType Type of argument
  * @param b Byte object
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl Object with shifted value
  */
-template<class IntegerType> constexpr ByteImpl
-operator<<(ByteImpl b, IntegerType shift) noexcept
-  requires std::integral<IntegerType>
+template<class IntegerType,
+         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+constexpr ByteImpl operator<<(ByteImpl b, IntegerType shift) noexcept
 {
     return ByteImpl(static_cast<ByteImpl::ByteType>(b) << shift);
 }
 
 /**
- * @brief Left shift operator with assigment for Byte object
+ * @brief Left shift operator with assigment for Byte object.
  *
  * @tparam IntegerType Type of argument
  * @param b Byte object
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl& Reference to object with shifted value
  */
-template<class IntegerType> constexpr ByteImpl&
-operator<<=(ByteImpl& b, IntegerType shift) noexcept
-  requires std::integral<IntegerType>
+template<class IntegerType,
+         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+constexpr ByteImpl& operator<<=(ByteImpl& b, IntegerType shift) noexcept
 {
     return b = b << shift;
 }
 
 /**
- * @brief Right shift operator for Byte object
+ * @brief Right shift operator for Byte object.
  *
  * @tparam IntegerType Type of argument
  * @param b Byte object
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl Object with shifted value
  */
-template<class IntegerType> constexpr ByteImpl
-operator>>(ByteImpl b, IntegerType shift) noexcept
-  requires std::integral<IntegerType>
+template<class IntegerType,
+         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+constexpr ByteImpl operator>>(ByteImpl b, IntegerType shift) noexcept
 {
     return ByteImpl(static_cast<ByteImpl::ByteType>(b) >> shift);
 }
 
 /**
- * @brief Right shift operator with assigment for Byte object
+ * @brief Right shift operator with assigment for Byte object.
  *
  * @tparam IntegerType Type of argument
  * @param b Byte object
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl& Reference to object with shifted value
  */
-template<class IntegerType> constexpr ByteImpl&
-operator>>=(ByteImpl& b, IntegerType shift) noexcept
-  requires std::integral<IntegerType>
+template<class IntegerType,
+         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+constexpr ByteImpl& operator>>=(ByteImpl& b, IntegerType shift) noexcept
 {
     return b = b >> shift;
 }
 
 /**
- * @brief Bitwise OR operator for Byte object
+ * @brief Bitwise OR operator for Byte object.
  *
  * @param l First byte object
  * @param r Second byte object
@@ -159,7 +175,7 @@ constexpr ByteImpl operator|(ByteImpl l, ByteImpl r) noexcept
 }
 
 /**
- * @brief Bitwise OR operator with assigment for Byte object
+ * @brief Bitwise OR operator with assigment for Byte object.
  *
  * @param l First byte object
  * @param r Second byte object
@@ -171,7 +187,7 @@ constexpr ByteImpl& operator|=(ByteImpl& l, ByteImpl r) noexcept
 }
 
 /**
- * @brief Bitwise AND operator for Byte object
+ * @brief Bitwise AND operator for Byte object.
  *
  * @param l First byte object
  * @param r Second byte object
@@ -184,7 +200,7 @@ constexpr ByteImpl operator&(ByteImpl l, ByteImpl r) noexcept
 }
 
 /**
- * @brief Bitwise AND operator with assigment for Byte object
+ * @brief Bitwise AND operator with assigment for Byte object.
  *
  * @param l First byte object
  * @param r Second byte object
@@ -196,7 +212,7 @@ constexpr ByteImpl& operator&=(ByteImpl& l, ByteImpl r) noexcept
 }
 
 /**
- * @brief Bitwise XOR operator for Byte object
+ * @brief Bitwise XOR operator for Byte object.
  *
  * @param l First byte object
  * @param r Second byte object
@@ -209,7 +225,7 @@ constexpr ByteImpl operator^(ByteImpl l, ByteImpl r) noexcept
 }
 
 /**
- * @brief Bitwise XOR operator with assigment for Byte object
+ * @brief Bitwise XOR operator with assigment for Byte object.
  *
  * @param l First byte object
  * @param r Second byte object
@@ -221,7 +237,7 @@ constexpr ByteImpl& operator^=(ByteImpl& l, ByteImpl r) noexcept
 }
 
 /**
- * @brief Bit inversion operator for Byte object
+ * @brief Bit inversion operator for Byte object.
  *
  * @param b Byte object
  * @return constexpr ByteImpl Object with value after inverting bits

--- a/include/ara/core/byte.h
+++ b/include/ara/core/byte.h
@@ -27,9 +27,10 @@ class ByteImpl
      * @req {SWS_CORE_10104}
      */
     ByteImpl() = default;
+
     /**
      * @brief Constuct object with given value.
-     * @arg Value of byte
+     * @param Value of byte
      *
      * @req {SWS_CORE_10102, SWS_CORE_10103}
      */
@@ -57,25 +58,27 @@ class ByteImpl
     /**
      * @brief Equality operator for Byte object.
      *
+     * @param rhs Byte object to compare with
      * @return true When given Byte object is equal
      * @return false When given Byte object is not equal
      * @req {SWS_CORE_10109}
      */
-    constexpr bool operator==(const ByteImpl& secondByteObject) const
+    constexpr bool operator==(const ByteImpl& rhs) const
     {
-        return impl == secondByteObject.impl;
+        return impl == rhs.impl;
     }
 
     /**
-     * @brief Not-equality operator for Byte object.
+     * @brief Non-equality operator for Byte object.
      *
+     * @param rhs Byte object to compare with
      * @return true When given Byte object is not equal
      * @return false When given Byte object equal
      * @req {SWS_CORE_10110}
      */
-    constexpr bool operator!=(const ByteImpl& secondByteObject) const
+    constexpr bool operator!=(const ByteImpl& rhs) const
     {
-        return ! (*this == secondByteObject);
+        return ! (*this == rhs);
     }
 
  private:

--- a/include/ara/core/byte.h
+++ b/include/ara/core/byte.h
@@ -94,8 +94,9 @@ class ByteImpl
  * @param b Byte object
  * @return constexpr IntegerType Integer value
  */
-template<class IntegerType,
-         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+template<
+  class IntegerType,
+  class = typename std::enable_if<std::is_integral<IntegerType>::value>::type>
 constexpr IntegerType to_integer(ByteImpl b) noexcept
 {
     return IntegerType(static_cast<ByteImpl::ByteType>(b));
@@ -109,8 +110,9 @@ constexpr IntegerType to_integer(ByteImpl b) noexcept
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl Object with shifted value
  */
-template<class IntegerType,
-         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+template<
+  class IntegerType,
+  class = typename std::enable_if<std::is_integral<IntegerType>::value>::type>
 constexpr ByteImpl operator<<(ByteImpl b, IntegerType shift) noexcept
 {
     return ByteImpl(static_cast<ByteImpl::ByteType>(b) << shift);
@@ -124,8 +126,9 @@ constexpr ByteImpl operator<<(ByteImpl b, IntegerType shift) noexcept
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl& Reference to object with shifted value
  */
-template<class IntegerType,
-         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+template<
+  class IntegerType,
+  class = typename std::enable_if<std::is_integral<IntegerType>::value>::type>
 constexpr ByteImpl& operator<<=(ByteImpl& b, IntegerType shift) noexcept
 {
     return b = b << shift;
@@ -139,8 +142,9 @@ constexpr ByteImpl& operator<<=(ByteImpl& b, IntegerType shift) noexcept
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl Object with shifted value
  */
-template<class IntegerType,
-         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+template<
+  class IntegerType,
+  class = typename std::enable_if<std::is_integral<IntegerType>::value>::type>
 constexpr ByteImpl operator>>(ByteImpl b, IntegerType shift) noexcept
 {
     return ByteImpl(static_cast<ByteImpl::ByteType>(b) >> shift);
@@ -154,8 +158,9 @@ constexpr ByteImpl operator>>(ByteImpl b, IntegerType shift) noexcept
  * @param shift Amount of bits to shift
  * @return constexpr ByteImpl& Reference to object with shifted value
  */
-template<class IntegerType,
-         typename = std::enable_if<std::is_integral<IntegerType>::value>::type>
+template<
+  class IntegerType,
+  class = typename std::enable_if<std::is_integral<IntegerType>::value>::type>
 constexpr ByteImpl& operator>>=(ByteImpl& b, IntegerType shift) noexcept
 {
     return b = b >> shift;

--- a/include/ara/core/byte.h
+++ b/include/ara/core/byte.h
@@ -11,8 +11,9 @@
 #include <cstddef>
 
 namespace ara::core {
-class ByteImpl {
-public:
+class ByteImpl
+{
+ public:
     using ByteType = uint8_t;
 
     ByteImpl() = default;
@@ -29,11 +30,83 @@ public:
 
     constexpr bool operator!=(const ByteImpl&) const = default;
 
-private:
+ private:
     std::byte impl;
 };
 
-using Byte = ByteImpl;
-} // namespace ara::com
+template<class IntegerType> constexpr IntegerType
+to_integer(ByteImpl b) noexcept requires std::integral<IntegerType>
+{
+    return IntegerType(static_cast<ByteImpl::ByteType>(b));
+}
 
-#endif // ARA_CORE_BYTE_H_
+template<class IntegerType> constexpr ByteImpl
+operator<<(ByteImpl b, IntegerType shift) noexcept
+  requires std::integral<IntegerType>
+{
+    return ByteImpl(static_cast<ByteImpl::ByteType>(b) << shift);
+}
+
+template<class IntegerType> constexpr ByteImpl&
+operator<<=(ByteImpl& b, IntegerType shift) noexcept
+  requires std::integral<IntegerType>
+{
+    return b = b << shift;
+}
+
+template<class IntegerType> constexpr ByteImpl
+operator>>(ByteImpl b, IntegerType shift) noexcept
+  requires std::integral<IntegerType>
+{
+    return ByteImpl(static_cast<ByteImpl::ByteType>(b) >> shift);
+}
+
+template<class IntegerType> constexpr ByteImpl&
+operator>>=(ByteImpl& b, IntegerType shift) noexcept
+  requires std::integral<IntegerType>
+{
+    return b = b >> shift;
+}
+
+constexpr ByteImpl operator|(ByteImpl l, ByteImpl r) noexcept
+{
+    return ByteImpl(static_cast<ByteImpl::ByteType>(l)
+                    | static_cast<ByteImpl::ByteType>(r));
+}
+
+constexpr ByteImpl& operator|=(ByteImpl& l, ByteImpl r) noexcept
+{
+    return l = l | r;
+}
+
+constexpr ByteImpl operator&(ByteImpl l, ByteImpl r) noexcept
+{
+    return ByteImpl(static_cast<ByteImpl::ByteType>(l)
+                    & static_cast<ByteImpl::ByteType>(r));
+}
+
+constexpr ByteImpl& operator&=(ByteImpl& l, ByteImpl r) noexcept
+{
+    return l = l & r;
+}
+
+constexpr ByteImpl operator^(ByteImpl l, ByteImpl r) noexcept
+{
+    return ByteImpl(static_cast<ByteImpl::ByteType>(l)
+                    ^ static_cast<ByteImpl::ByteType>(r));
+}
+
+constexpr ByteImpl& operator^=(ByteImpl& l, ByteImpl r) noexcept
+{
+    return l = l ^ r;
+}
+
+constexpr ByteImpl operator~(ByteImpl b) noexcept
+{
+    return ByteImpl(~static_cast<ByteImpl::ByteType>(b));
+}
+
+using Byte = ByteImpl;
+}  // namespace ara::core
+
+#endif  // ARA_CORE_BYTE_H_

--- a/include/ara/core/byte.h
+++ b/include/ara/core/byte.h
@@ -11,35 +11,84 @@
 #include <cstddef>
 
 namespace ara::core {
+/**
+ * @brief Wrapper class for std::byte class
+ *
+ */
 class ByteImpl
 {
  public:
     using ByteType = uint8_t;
 
+    /**
+     * @brief Construct a new Byte Impl object with no defined value
+     *
+     */
     ByteImpl() = default;
+    /**
+     * @brief Constuct object with given value
+     * @arg Value of byte
+     *
+     */
     constexpr explicit ByteImpl(ByteType value) : impl{value} {}
 
+    /**
+     * @brief Default destructor
+     *
+     */
     ~ByteImpl() = default;
 
+    /**
+     * @brief Cast operator for machine byte type
+     *
+     * @return ByteType Value of byte given in byte machine type
+     */
     constexpr explicit operator ByteType() const
     {
         return static_cast<ByteType>(impl);
     }
 
+    /**
+     * @brief Equality operator for Byte object
+     *
+     * @return true When given Byte object is equal
+     * @return false When given Byte object is not equal
+     */
     constexpr bool operator==(const ByteImpl&) const = default;
 
+    /**
+     * @brief No equality operator for Byte object
+     *
+     * @return true When given Byte object is not equal
+     * @return false When given Byte object is equal
+     */
     constexpr bool operator!=(const ByteImpl&) const = default;
 
  private:
     std::byte impl;
 };
 
+/**
+ * @brief Gives value of Byte object as integer.
+ *
+ * @tparam IntegerType Exact type of integer to return
+ * @param b Byte object
+ * @return constexpr IntegerType Integer value
+ */
 template<class IntegerType> constexpr IntegerType
 to_integer(ByteImpl b) noexcept requires std::integral<IntegerType>
 {
     return IntegerType(static_cast<ByteImpl::ByteType>(b));
 }
 
+/**
+ * @brief Left shift operator for Byte object
+ *
+ * @tparam IntegerType Type of integer used by argument
+ * @param b Byte object
+ * @param shift Amount bits to shift
+ * @return constexpr ByteImpl Object with shifted value
+ */
 template<class IntegerType> constexpr ByteImpl
 operator<<(ByteImpl b, IntegerType shift) noexcept
   requires std::integral<IntegerType>
@@ -47,6 +96,14 @@ operator<<(ByteImpl b, IntegerType shift) noexcept
     return ByteImpl(static_cast<ByteImpl::ByteType>(b) << shift);
 }
 
+/**
+ * @brief Left shift operator with assigment for Byte object
+ *
+ * @tparam IntegerType Type of integer used by argument
+ * @param b Byte object
+ * @param shift Amount bits to shift
+ * @return constexpr ByteImpl& Reference to object with shifted value
+ */
 template<class IntegerType> constexpr ByteImpl&
 operator<<=(ByteImpl& b, IntegerType shift) noexcept
   requires std::integral<IntegerType>
@@ -54,6 +111,14 @@ operator<<=(ByteImpl& b, IntegerType shift) noexcept
     return b = b << shift;
 }
 
+/**
+ * @brief Right shift operator for Byte object
+ *
+ * @tparam IntegerType Type of integer used by argument
+ * @param b Byte object
+ * @param shift Amount bits to shift
+ * @return constexpr ByteImpl Object with shifted value
+ */
 template<class IntegerType> constexpr ByteImpl
 operator>>(ByteImpl b, IntegerType shift) noexcept
   requires std::integral<IntegerType>
@@ -61,6 +126,14 @@ operator>>(ByteImpl b, IntegerType shift) noexcept
     return ByteImpl(static_cast<ByteImpl::ByteType>(b) >> shift);
 }
 
+/**
+ * @brief Right shift operator with assigment for Byte object
+ *
+ * @tparam IntegerType Type of integer used by argument
+ * @param b Byte object
+ * @param shift Amount bits to shift
+ * @return constexpr ByteImpl& Reference to object with shifted value
+ */
 template<class IntegerType> constexpr ByteImpl&
 operator>>=(ByteImpl& b, IntegerType shift) noexcept
   requires std::integral<IntegerType>
@@ -68,45 +141,92 @@ operator>>=(ByteImpl& b, IntegerType shift) noexcept
     return b = b >> shift;
 }
 
+/**
+ * @brief Bitwise OR operator for Byte object
+ *
+ * @param l Left byte object
+ * @param r Right byte object
+ * @return constexpr ByteImpl Object with result of OR operation
+ */
 constexpr ByteImpl operator|(ByteImpl l, ByteImpl r) noexcept
 {
     return ByteImpl(static_cast<ByteImpl::ByteType>(l)
                     | static_cast<ByteImpl::ByteType>(r));
 }
 
+/**
+ * @brief Bitwise OR operator with assigment for Byte object
+ *
+ * @param l Left byte object
+ * @param r Right byte object
+ * @return constexpr ByteImpl& Reference to object with result of OR operation
+ */
 constexpr ByteImpl& operator|=(ByteImpl& l, ByteImpl r) noexcept
 {
     return l = l | r;
 }
 
+/**
+ * @brief Bitwise AND operator for Byte object
+ *
+ * @param l Left byte object
+ * @param r Right byte object
+ * @return constexpr ByteImpl Object with result of AND operation
+ */
 constexpr ByteImpl operator&(ByteImpl l, ByteImpl r) noexcept
 {
     return ByteImpl(static_cast<ByteImpl::ByteType>(l)
                     & static_cast<ByteImpl::ByteType>(r));
 }
 
+/**
+ * @brief Bitwise AND operator with assigment for Byte object
+ *
+ * @param l Left byte object
+ * @param r Right byte object
+ * @return constexpr ByteImpl& Reference to object with result of AND operation
+ */
 constexpr ByteImpl& operator&=(ByteImpl& l, ByteImpl r) noexcept
 {
     return l = l & r;
 }
 
+/**
+ * @brief Bitwise XOR operator for Byte object
+ *
+ * @param l Left byte object
+ * @param r Right byte object
+ * @return constexpr ByteImpl Object with result of XOR operation
+ */
 constexpr ByteImpl operator^(ByteImpl l, ByteImpl r) noexcept
 {
     return ByteImpl(static_cast<ByteImpl::ByteType>(l)
                     ^ static_cast<ByteImpl::ByteType>(r));
 }
 
+/**
+ * @brief Bitwise XOR operator with assigment for Byte object
+ *
+ * @param l Left byte object
+ * @param r Right byte object
+ * @return constexpr ByteImpl& Reference to object with result of XOR operation
+ */
 constexpr ByteImpl& operator^=(ByteImpl& l, ByteImpl r) noexcept
 {
     return l = l ^ r;
 }
 
+/**
+ * @brief Bit inversion oprator for Byte object
+ *
+ * @param b Byte object
+ * @return constexpr ByteImpl Object with value after inverting bits
+ */
 constexpr ByteImpl operator~(ByteImpl b) noexcept
 {
     return ByteImpl(~static_cast<ByteImpl::ByteType>(b));
 }
 
-using Byte = ByteImpl;
 }  // namespace ara::core
 
 #endif  // ARA_CORE_BYTE_H_

--- a/include/ara/core/byte.h
+++ b/include/ara/core/byte.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2020
+ * umlaut Software Development and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ARA_CORE_BYTE_H_
+#define ARA_CORE_BYTE_H_
+
+#include <cstddef>
+
+namespace ara::core {
+class ByteImpl {
+public:
+    using ByteType = uint8_t;
+
+    ByteImpl() = default;
+    constexpr explicit ByteImpl(ByteType value) : impl{value} {}
+
+    ~ByteImpl() = default;
+
+    constexpr explicit operator ByteType() const
+    {
+        return static_cast<ByteType>(impl);
+    }
+
+    constexpr bool operator==(const ByteImpl&) const = default;
+
+    constexpr bool operator!=(const ByteImpl&) const = default;
+
+private:
+    std::byte impl;
+};
+
+using Byte = ByteImpl;
+} // namespace ara::com
+
+#endif // ARA_CORE_BYTE_H_

--- a/include/ara/core/utility.h
+++ b/include/ara/core/utility.h
@@ -9,7 +9,7 @@
 
 #include <utility>
 
-#include "byte.h"
+#include "ara/core/byte.h"
 
 namespace ara::core {
 /**

--- a/include/ara/core/utility.h
+++ b/include/ara/core/utility.h
@@ -9,6 +9,8 @@
 
 #include <utility>
 
+#include "byte.h"
+
 namespace ara::core {
 /**
  * It is a type that is able to hold a “byte” of the machine.
@@ -16,7 +18,7 @@ namespace ara::core {
  *
  * @req {SWS_CORE_04200}
  */
-using Byte = std::byte;  // TODO: to change with custom implementation
+using Byte = ByteImpl;
 
 /**
  * An instance of this type can be passed to certain constructors of

--- a/tests/byte_test.cpp
+++ b/tests/byte_test.cpp
@@ -49,7 +49,7 @@ TEST_CASE("ByteImpl is not implicitly convertible from any other type",
 }
 
 TEST_CASE("ByteImpl is not implicitly convertible to any other type",
-          "[SWS_CORE], [SWS_CORE_10106]")
+          "[SWS_CORE], [SWS_CORE_10107]")
 {
     REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, uint8_t>);
     REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, int>);
@@ -57,7 +57,7 @@ TEST_CASE("ByteImpl is not implicitly convertible to any other type",
 }
 
 TEST_CASE("ByteImpl can be converted to unsigned char",
-          "[SWS_CORE], [SWS_CORE_10106]")
+          "[SWS_CORE], [SWS_CORE_10108]")
 {
     WHEN("Not in constant expression")
     {
@@ -77,7 +77,7 @@ TEST_CASE("ByteImpl can be converted to unsigned char",
 }
 
 TEST_CASE("ByteImpl shall be comparable for equality",
-          "[SWS_CORE], [SWS_CORE_10106]")
+          "[SWS_CORE], [SWS_CORE_10109]")
 {
     WHEN("ByteImpl objects are equal")
     {
@@ -93,7 +93,7 @@ TEST_CASE("ByteImpl shall be comparable for equality",
 }
 
 TEST_CASE("ByteImpl shall be comparable for non-equality",
-          "[SWS_CORE], [SWS_CORE_10106]")
+          "[SWS_CORE], [SWS_CORE_10110]")
 {
     WHEN("ByteImpl objects are equal")
     {

--- a/tests/byte_test.cpp
+++ b/tests/byte_test.cpp
@@ -4,119 +4,120 @@
 
 #include "ara/core/byte.h"
 
-TEST_CASE("Byte is not integral type", "[SWS_CORE_10100]")
+TEST_CASE("ByteImpl is not integral type", "[SWS_CORE_10100]")
 {
-    REQUIRE(std::is_integral_v<ara::core::Byte> == 0);
+    REQUIRE(std::is_integral_v<ara::core::ByteImpl> == 0);
 }
 
-TEST_CASE("Size of Byte is one", "[SWS_CORE_10101]")
+TEST_CASE("Size of ByteImpl is one", "[SWS_CORE_10101]")
 {
-    REQUIRE(sizeof(ara::core::Byte) == 1);
+    REQUIRE(sizeof(ara::core::ByteImpl) == 1);
 }
 
-TEST_CASE("Byte should be constrained in unsigned char limits",
+TEST_CASE("ByteImpl should be constrained in unsigned char limits",
           "[SWS_CORE_10102]")
 {
-    REQUIRE_NOTHROW(ara::core::Byte{0});
-    REQUIRE_NOTHROW(ara::core::Byte{std::numeric_limits<unsigned char>::max()});
+    REQUIRE_NOTHROW(ara::core::ByteImpl{0});
+    REQUIRE_NOTHROW(
+      ara::core::ByteImpl{std::numeric_limits<unsigned char>::max()});
 }
 
-TEST_CASE("Byte can be created with integral type", "[SWS_CORE_10103]")
+TEST_CASE("ByteImpl can be created with integral type", "[SWS_CORE_10103]")
 {
-    REQUIRE_NOTHROW(ara::core::Byte{1});
-    constexpr ara::core::Byte byte{2};
+    REQUIRE_NOTHROW(ara::core::ByteImpl{1});
+    constexpr ara::core::ByteImpl byte{2};
     REQUIRE_NOTHROW((void) byte);
 }
 
-TEST_CASE("Byte can be default constructed", "[SWS_CORE_10104]")
+TEST_CASE("ByteImpl can be default constructed", "[SWS_CORE_10104]")
 {
-    REQUIRE_NOTHROW(ara::core::Byte{});
+    REQUIRE_NOTHROW(ara::core::ByteImpl{});
 }
 
-TEST_CASE("Byte is trivially destructable", "[SWS_CORE_10105]")
+TEST_CASE("ByteImpl is trivially destructable", "[SWS_CORE_10105]")
 {
-    REQUIRE(std::is_trivially_destructible_v<ara::core::Byte>);
+    REQUIRE(std::is_trivially_destructible_v<ara::core::ByteImpl>);
 }
 
-TEST_CASE("Byte is not implicitly convertible from any other type",
+TEST_CASE("ByteImpl is not implicitly convertible from any other type",
           "[SWS_CORE_10106]")
 {
-    REQUIRE_FALSE(std::is_convertible_v<uint8_t, ara::core::Byte>);
-    REQUIRE_FALSE(std::is_convertible_v<int, ara::core::Byte>);
-    REQUIRE_FALSE(std::is_convertible_v<char, ara::core::Byte>);
+    REQUIRE_FALSE(std::is_convertible_v<uint8_t, ara::core::ByteImpl>);
+    REQUIRE_FALSE(std::is_convertible_v<int, ara::core::ByteImpl>);
+    REQUIRE_FALSE(std::is_convertible_v<char, ara::core::ByteImpl>);
 }
 
-TEST_CASE("Byte is not implicitly convertible to any other type",
+TEST_CASE("ByteImpl is not implicitly convertible to any other type",
           "[SWS_CORE_10106]")
 {
-    REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, uint8_t>);
-    REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, int>);
-    REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, char>);
+    REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, uint8_t>);
+    REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, int>);
+    REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, char>);
 }
 
-TEST_CASE("Byte can be converted to unsigned char", "[SWS_CORE_10106]")
+TEST_CASE("ByteImpl can be converted to unsigned char", "[SWS_CORE_10106]")
 {
     WHEN("Not in constant expression")
     {
         const unsigned char value{7};
-        ara::core::Byte     byteObject{value};
+        ara::core::ByteImpl byteObject{value};
         auto                byteValue = static_cast<unsigned char>(byteObject);
         REQUIRE(value == byteValue);
     }
 
     WHEN("In constant expression")
     {
-        const unsigned char       value{7};
-        constexpr ara::core::Byte byteObject{value};
+        const unsigned char           value{7};
+        constexpr ara::core::ByteImpl byteObject{value};
         constexpr auto byteValue = static_cast<unsigned char>(byteObject);
         REQUIRE(value == byteValue);
     }
 }
 
-TEST_CASE("Byte shall be comparable for equality", "[SWS_CORE_10106]")
+TEST_CASE("ByteImpl shall be comparable for equality", "[SWS_CORE_10106]")
 {
-    WHEN("Byte objects are equal")
+    WHEN("ByteImpl objects are equal")
     {
-        ara::core::Byte byteObject1{1}, byteObject2{1};
+        ara::core::ByteImpl byteObject1{1}, byteObject2{1};
         REQUIRE(byteObject1 == byteObject2);
     }
 
-    WHEN("Byte objects are not equal")
+    WHEN("ByteImpl objects are not equal")
     {
-        ara::core::Byte byteObject1{1}, byteObject2{2};
+        ara::core::ByteImpl byteObject1{1}, byteObject2{2};
         REQUIRE_FALSE(byteObject1 == byteObject2);
     }
 }
 
-TEST_CASE("Byte shall be comparable for non-equality", "[SWS_CORE_10106]")
+TEST_CASE("ByteImpl shall be comparable for non-equality", "[SWS_CORE_10106]")
 {
-    WHEN("Byte objects are equal")
+    WHEN("ByteImpl objects are equal")
     {
-        ara::core::Byte byteObject1{1}, byteObject2{1};
+        ara::core::ByteImpl byteObject1{1}, byteObject2{1};
         REQUIRE_FALSE(byteObject1 != byteObject2);
     }
 
-    WHEN("Byte objects are not equal")
+    WHEN("ByteImpl objects are not equal")
     {
-        ara::core::Byte byteObject1{1}, byteObject2{2};
+        ara::core::ByteImpl byteObject1{1}, byteObject2{2};
         REQUIRE(byteObject1 != byteObject2);
     }
 }
 
-TEST_CASE("Byte can be changed to Integral type", "[]")
+TEST_CASE("ByteImpl can be changed to Integral type", "[]")
 {
-    ara::core::Byte byteObject{1};
-    auto            int32Value(ara::core::to_integer<int32_t>(byteObject));
+    ara::core::ByteImpl byteObject{1};
+    auto                int32Value(ara::core::to_integer<int32_t>(byteObject));
     REQUIRE(int32Value == 1);
     auto uint16Value(ara::core::to_integer<uint16_t>(byteObject));
     REQUIRE(uint16Value == 1u);
 }
 
-TEST_CASE("Byte can be used with shift operators", "[]")
+TEST_CASE("ByteImpl can be used with shift operators", "[]")
 {
-    ara::core::Byte byteObject1{4}, byteObject2{1};
-    WHEN("Used operator >>") { REQUIRE(byteObject1 >> 2 == byteObject2); }
-    WHEN("Used operator <<") { REQUIRE(byteObject2 << 2 == byteObject1); }
+    ara::core::ByteImpl byteObject1{4}, byteObject2{1};
+    WHEN("Used operator >>") { REQUIRE((byteObject1 >> 2) == byteObject2); }
+    WHEN("Used operator <<") { REQUIRE((byteObject2 << 2) == byteObject1); }
     WHEN("Used operator >>=")
     {
         byteObject1 >>= 2;
@@ -129,15 +130,15 @@ TEST_CASE("Byte can be used with shift operators", "[]")
     }
 }
 
-TEST_CASE("Byte can be used with bitwise operators", "[]")
+TEST_CASE("ByteImpl can be used with bitwise operators", "[]")
 {
-    ara::core::Byte byteObject1{1}, byteObject2{2}, byteObject3{3};
+    ara::core::ByteImpl byteObject1{1}, byteObject2{2}, byteObject3{3};
     WHEN("Used |,&,^,~")
     {
-        REQUIRE((byteObject1 | byteObject3) == byteObject3);  // 01 | 11 = 11
-        REQUIRE((byteObject1 & byteObject3) == byteObject1);  // 01 & 11 = 01
-        REQUIRE((byteObject1 ^ byteObject3) == byteObject2);  // 01 ^ 11 = 10
-        REQUIRE((~ara::core::Byte{0xFE}) == byteObject1);     // ~0xFE = 0x01
+        REQUIRE((byteObject1 | byteObject3) == byteObject3);   // 01 | 11 = 11
+        REQUIRE((byteObject1 & byteObject3) == byteObject1);   // 01 & 11 = 01
+        REQUIRE((byteObject1 ^ byteObject3) == byteObject2);   // 01 ^ 11 = 10
+        REQUIRE((~ara::core::ByteImpl{0xFE}) == byteObject1);  // ~0xFE = 0x01
     }
     WHEN("Used |=")
     {

--- a/tests/byte_test.cpp
+++ b/tests/byte_test.cpp
@@ -4,43 +4,44 @@
 
 #include "ara/core/byte.h"
 
-TEST_CASE("ByteImpl is not integral type", "[SWS_CORE_10100]")
+TEST_CASE("ByteImpl is not integral type", "[SWS_CORE], [SWS_CORE_10100]")
 {
     REQUIRE(std::is_integral_v<ara::core::ByteImpl> == 0);
 }
 
-TEST_CASE("Size of ByteImpl is one", "[SWS_CORE_10101]")
+TEST_CASE("Size of ByteImpl is one", "[SWS_CORE], [SWS_CORE_10101]")
 {
     REQUIRE(sizeof(ara::core::ByteImpl) == 1);
 }
 
 TEST_CASE("ByteImpl should be constrained in unsigned char limits",
-          "[SWS_CORE_10102]")
+          "[SWS_CORE], [SWS_CORE_10102]")
 {
     REQUIRE_NOTHROW(ara::core::ByteImpl{0});
     REQUIRE_NOTHROW(
       ara::core::ByteImpl{std::numeric_limits<unsigned char>::max()});
 }
 
-TEST_CASE("ByteImpl can be created with integral type", "[SWS_CORE_10103]")
+TEST_CASE("ByteImpl can be created with integral type",
+          "[SWS_CORE], [SWS_CORE_10103]")
 {
     REQUIRE_NOTHROW(ara::core::ByteImpl{1});
     constexpr ara::core::ByteImpl byte{2};
     REQUIRE_NOTHROW((void) byte);
 }
 
-TEST_CASE("ByteImpl can be default constructed", "[SWS_CORE_10104]")
+TEST_CASE("ByteImpl can be default constructed", "[SWS_CORE], [SWS_CORE_10104]")
 {
     REQUIRE_NOTHROW(ara::core::ByteImpl{});
 }
 
-TEST_CASE("ByteImpl is trivially destructable", "[SWS_CORE_10105]")
+TEST_CASE("ByteImpl is trivially destructable", "[SWS_CORE], [SWS_CORE_10105]")
 {
     REQUIRE(std::is_trivially_destructible_v<ara::core::ByteImpl>);
 }
 
 TEST_CASE("ByteImpl is not implicitly convertible from any other type",
-          "[SWS_CORE_10106]")
+          "[SWS_CORE], [SWS_CORE_10106]")
 {
     REQUIRE_FALSE(std::is_convertible_v<uint8_t, ara::core::ByteImpl>);
     REQUIRE_FALSE(std::is_convertible_v<int, ara::core::ByteImpl>);
@@ -48,14 +49,15 @@ TEST_CASE("ByteImpl is not implicitly convertible from any other type",
 }
 
 TEST_CASE("ByteImpl is not implicitly convertible to any other type",
-          "[SWS_CORE_10106]")
+          "[SWS_CORE], [SWS_CORE_10106]")
 {
     REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, uint8_t>);
     REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, int>);
     REQUIRE_FALSE(std::is_convertible_v<ara::core::ByteImpl, char>);
 }
 
-TEST_CASE("ByteImpl can be converted to unsigned char", "[SWS_CORE_10106]")
+TEST_CASE("ByteImpl can be converted to unsigned char",
+          "[SWS_CORE], [SWS_CORE_10106]")
 {
     WHEN("Not in constant expression")
     {
@@ -74,7 +76,8 @@ TEST_CASE("ByteImpl can be converted to unsigned char", "[SWS_CORE_10106]")
     }
 }
 
-TEST_CASE("ByteImpl shall be comparable for equality", "[SWS_CORE_10106]")
+TEST_CASE("ByteImpl shall be comparable for equality",
+          "[SWS_CORE], [SWS_CORE_10106]")
 {
     WHEN("ByteImpl objects are equal")
     {
@@ -89,7 +92,8 @@ TEST_CASE("ByteImpl shall be comparable for equality", "[SWS_CORE_10106]")
     }
 }
 
-TEST_CASE("ByteImpl shall be comparable for non-equality", "[SWS_CORE_10106]")
+TEST_CASE("ByteImpl shall be comparable for non-equality",
+          "[SWS_CORE], [SWS_CORE_10106]")
 {
     WHEN("ByteImpl objects are equal")
     {
@@ -104,7 +108,7 @@ TEST_CASE("ByteImpl shall be comparable for non-equality", "[SWS_CORE_10106]")
     }
 }
 
-TEST_CASE("ByteImpl can be changed to Integral type", "[]")
+TEST_CASE("ByteImpl can be changed to Integral type", "[SWS_CORE]")
 {
     ara::core::ByteImpl byteObject{1};
     auto                int32Value(ara::core::to_integer<int32_t>(byteObject));
@@ -113,44 +117,44 @@ TEST_CASE("ByteImpl can be changed to Integral type", "[]")
     REQUIRE(uint16Value == 1u);
 }
 
-TEST_CASE("ByteImpl can be used with shift operators", "[]")
+TEST_CASE("ByteImpl can be used with shift operators", "[SWS_CORE]")
 {
     ara::core::ByteImpl byteObject1{4}, byteObject2{1};
-    WHEN("Used operator >>") { REQUIRE((byteObject1 >> 2) == byteObject2); }
-    WHEN("Used operator <<") { REQUIRE((byteObject2 << 2) == byteObject1); }
-    WHEN("Used operator >>=")
+    WHEN("Using operator >>") { REQUIRE((byteObject1 >> 2) == byteObject2); }
+    WHEN("Using operator <<") { REQUIRE((byteObject2 << 2) == byteObject1); }
+    WHEN("Using operator >>=")
     {
         byteObject1 >>= 2;
         REQUIRE(byteObject1 == byteObject2);
     }
-    WHEN("Used operator <<=")
+    WHEN("Using operator <<=")
     {
         byteObject2 <<= 2;
         REQUIRE(byteObject2 == byteObject1);
     }
 }
 
-TEST_CASE("ByteImpl can be used with bitwise operators", "[]")
+TEST_CASE("ByteImpl can be used with bitwise operators", "[SWS_CORE]")
 {
     ara::core::ByteImpl byteObject1{1}, byteObject2{2}, byteObject3{3};
-    WHEN("Used |,&,^,~")
+    WHEN("Using |,&,^,~")
     {
         REQUIRE((byteObject1 | byteObject3) == byteObject3);   // 01 | 11 = 11
         REQUIRE((byteObject1 & byteObject3) == byteObject1);   // 01 & 11 = 01
         REQUIRE((byteObject1 ^ byteObject3) == byteObject2);   // 01 ^ 11 = 10
         REQUIRE((~ara::core::ByteImpl{0xFE}) == byteObject1);  // ~0xFE = 0x01
     }
-    WHEN("Used |=")
+    WHEN("Using |=")
     {
         byteObject1 |= byteObject3;
         REQUIRE(byteObject1 == byteObject3);
     }
-    WHEN("Used &=")
+    WHEN("Using &=")
     {
         byteObject3 &= byteObject1;
         REQUIRE(byteObject1 == byteObject3);
     }
-    WHEN("Used ^=")
+    WHEN("Using ^=")
     {
         byteObject1 ^= byteObject3;
         REQUIRE(byteObject1 == byteObject2);

--- a/tests/byte_test.cpp
+++ b/tests/byte_test.cpp
@@ -14,7 +14,8 @@ TEST_CASE("Size of Byte is one", "[SWS_CORE_10101]")
     REQUIRE(sizeof(ara::core::Byte) == 1);
 }
 
-TEST_CASE("Byte should be constrained in unsigned char limits", "[SWS_CORE_10102]")
+TEST_CASE("Byte should be constrained in unsigned char limits",
+          "[SWS_CORE_10102]")
 {
     REQUIRE_NOTHROW(ara::core::Byte{0});
     REQUIRE_NOTHROW(ara::core::Byte{std::numeric_limits<unsigned char>::max()});
@@ -24,6 +25,7 @@ TEST_CASE("Byte can be created with integral type", "[SWS_CORE_10103]")
 {
     REQUIRE_NOTHROW(ara::core::Byte{1});
     constexpr ara::core::Byte byte{2};
+    REQUIRE_NOTHROW((void) byte);
 }
 
 TEST_CASE("Byte can be default constructed", "[SWS_CORE_10104]")
@@ -36,14 +38,16 @@ TEST_CASE("Byte is trivially destructable", "[SWS_CORE_10105]")
     REQUIRE(std::is_trivially_destructible_v<ara::core::Byte>);
 }
 
-TEST_CASE("Byte is not implicitly convertible from any other type", "[SWS_CORE_10106]")
+TEST_CASE("Byte is not implicitly convertible from any other type",
+          "[SWS_CORE_10106]")
 {
     REQUIRE_FALSE(std::is_convertible_v<uint8_t, ara::core::Byte>);
     REQUIRE_FALSE(std::is_convertible_v<int, ara::core::Byte>);
     REQUIRE_FALSE(std::is_convertible_v<char, ara::core::Byte>);
 }
 
-TEST_CASE("Byte is not implicitly convertible to any other type", "[SWS_CORE_10106]")
+TEST_CASE("Byte is not implicitly convertible to any other type",
+          "[SWS_CORE_10106]")
 {
     REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, uint8_t>);
     REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, int>);
@@ -54,15 +58,15 @@ TEST_CASE("Byte can be converted to unsigned char", "[SWS_CORE_10106]")
 {
     WHEN("Not in constant expression")
     {
-        unsigned char value{7};
-        ara::core::Byte byteObject{value};
-        auto byteValue = static_cast<unsigned char>(byteObject);
+        const unsigned char value{7};
+        ara::core::Byte     byteObject{value};
+        auto                byteValue = static_cast<unsigned char>(byteObject);
         REQUIRE(value == byteValue);
     }
 
     WHEN("In constant expression")
     {
-        constexpr unsigned char value{7};
+        const unsigned char       value{7};
         constexpr ara::core::Byte byteObject{value};
         constexpr auto byteValue = static_cast<unsigned char>(byteObject);
         REQUIRE(value == byteValue);
@@ -99,3 +103,55 @@ TEST_CASE("Byte shall be comparable for non-equality", "[SWS_CORE_10106]")
     }
 }
 
+TEST_CASE("Byte can be changed to Integral type", "[]")
+{
+    ara::core::Byte byteObject{1};
+    auto            int32Value(ara::core::to_integer<int32_t>(byteObject));
+    REQUIRE(int32Value == 1);
+    auto uint16Value(ara::core::to_integer<uint16_t>(byteObject));
+    REQUIRE(uint16Value == 1u);
+}
+
+TEST_CASE("Byte can be used with shift operators", "[]")
+{
+    ara::core::Byte byteObject1{4}, byteObject2{1};
+    WHEN("Used operator >>") { REQUIRE(byteObject1 >> 2 == byteObject2); }
+    WHEN("Used operator <<") { REQUIRE(byteObject2 << 2 == byteObject1); }
+    WHEN("Used operator >>=")
+    {
+        byteObject1 >>= 2;
+        REQUIRE(byteObject1 == byteObject2);
+    }
+    WHEN("Used operator <<=")
+    {
+        byteObject2 <<= 2;
+        REQUIRE(byteObject2 == byteObject1);
+    }
+}
+
+TEST_CASE("Byte can be used with bitwise operators", "[]")
+{
+    ara::core::Byte byteObject1{1}, byteObject2{2}, byteObject3{3};
+    WHEN("Used |,&,^,~")
+    {
+        REQUIRE((byteObject1 | byteObject3) == byteObject3);  // 01 | 11 = 11
+        REQUIRE((byteObject1 & byteObject3) == byteObject1);  // 01 & 11 = 01
+        REQUIRE((byteObject1 ^ byteObject3) == byteObject2);  // 01 ^ 11 = 10
+        REQUIRE((~ara::core::Byte{0xFE}) == byteObject1);     // ~0xFE = 0x01
+    }
+    WHEN("Used |=")
+    {
+        byteObject1 |= byteObject3;
+        REQUIRE(byteObject1 == byteObject3);
+    }
+    WHEN("Used &=")
+    {
+        byteObject3 &= byteObject1;
+        REQUIRE(byteObject1 == byteObject3);
+    }
+    WHEN("Used ^=")
+    {
+        byteObject1 ^= byteObject3;
+        REQUIRE(byteObject1 == byteObject2);
+    }
+}

--- a/tests/byte_test.cpp
+++ b/tests/byte_test.cpp
@@ -1,0 +1,101 @@
+#include <catch2/catch.hpp>
+
+#include <type_traits>
+
+#include "ara/core/byte.h"
+
+TEST_CASE("Byte is not integral type", "[SWS_CORE_10100]")
+{
+    REQUIRE(std::is_integral_v<ara::core::Byte> == 0);
+}
+
+TEST_CASE("Size of Byte is one", "[SWS_CORE_10101]")
+{
+    REQUIRE(sizeof(ara::core::Byte) == 1);
+}
+
+TEST_CASE("Byte should be constrained in unsigned char limits", "[SWS_CORE_10102]")
+{
+    REQUIRE_NOTHROW(ara::core::Byte{0});
+    REQUIRE_NOTHROW(ara::core::Byte{std::numeric_limits<unsigned char>::max()});
+}
+
+TEST_CASE("Byte can be created with integral type", "[SWS_CORE_10103]")
+{
+    REQUIRE_NOTHROW(ara::core::Byte{1});
+    constexpr ara::core::Byte byte{2};
+}
+
+TEST_CASE("Byte can be default constructed", "[SWS_CORE_10104]")
+{
+    REQUIRE_NOTHROW(ara::core::Byte{});
+}
+
+TEST_CASE("Byte is trivially destructable", "[SWS_CORE_10105]")
+{
+    REQUIRE(std::is_trivially_destructible_v<ara::core::Byte>);
+}
+
+TEST_CASE("Byte is not implicitly convertible from any other type", "[SWS_CORE_10106]")
+{
+    REQUIRE_FALSE(std::is_convertible_v<uint8_t, ara::core::Byte>);
+    REQUIRE_FALSE(std::is_convertible_v<int, ara::core::Byte>);
+    REQUIRE_FALSE(std::is_convertible_v<char, ara::core::Byte>);
+}
+
+TEST_CASE("Byte is not implicitly convertible to any other type", "[SWS_CORE_10106]")
+{
+    REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, uint8_t>);
+    REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, int>);
+    REQUIRE_FALSE(std::is_convertible_v<ara::core::Byte, char>);
+}
+
+TEST_CASE("Byte can be converted to unsigned char", "[SWS_CORE_10106]")
+{
+    WHEN("Not in constant expression")
+    {
+        unsigned char value{7};
+        ara::core::Byte byteObject{value};
+        auto byteValue = static_cast<unsigned char>(byteObject);
+        REQUIRE(value == byteValue);
+    }
+
+    WHEN("In constant expression")
+    {
+        constexpr unsigned char value{7};
+        constexpr ara::core::Byte byteObject{value};
+        constexpr auto byteValue = static_cast<unsigned char>(byteObject);
+        REQUIRE(value == byteValue);
+    }
+}
+
+TEST_CASE("Byte shall be comparable for equality", "[SWS_CORE_10106]")
+{
+    WHEN("Byte objects are equal")
+    {
+        ara::core::Byte byteObject1{1}, byteObject2{1};
+        REQUIRE(byteObject1 == byteObject2);
+    }
+
+    WHEN("Byte objects are not equal")
+    {
+        ara::core::Byte byteObject1{1}, byteObject2{2};
+        REQUIRE_FALSE(byteObject1 == byteObject2);
+    }
+}
+
+TEST_CASE("Byte shall be comparable for non-equality", "[SWS_CORE_10106]")
+{
+    WHEN("Byte objects are equal")
+    {
+        ara::core::Byte byteObject1{1}, byteObject2{1};
+        REQUIRE_FALSE(byteObject1 != byteObject2);
+    }
+
+    WHEN("Byte objects are not equal")
+    {
+        ara::core::Byte byteObject1{1}, byteObject2{2};
+        REQUIRE(byteObject1 != byteObject2);
+    }
+}
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,7 +5,8 @@ srcs = [
     'array_test.cpp',
     'map_test.cpp',
     'vector_test.cpp',
-    'utility_test.cpp'
+    'utility_test.cpp',
+    'byte_test.cpp'
 ]
 
 # Add `include` to include directories


### PR DESCRIPTION
Implementing requirements for ara::core::Byte type (SWS_CORE_10101 - SWS_CORE_10110). Created wrapper class for std::byte and defining all functions for ara::core::byte, as for std::byte in the standard library.

Issue: #41 